### PR TITLE
Fix `_get_offset` when run outside of a git repo

### DIFF
--- a/cruft/_commands/update.py
+++ b/cruft/_commands/update.py
@@ -123,13 +123,13 @@ def _is_project_repo_clean(directory: Path):
 
 
 def _apply_patch_with_rejections(diff: str, expanded_dir_path: Path):
+    offset = _get_offset(expanded_dir_path)
+
+    git_apply = ["git", "apply", "--reject"]
+    if offset:
+        git_apply.extend(["--directory", offset])
+
     try:
-        offset = _get_offset(expanded_dir_path)
-
-        git_apply = ["git", "apply", "-3"]
-        if offset:
-            git_apply.extend(["--directory", offset])
-
         run(
             git_apply,
             input=diff.encode(),
@@ -150,13 +150,13 @@ def _apply_patch_with_rejections(diff: str, expanded_dir_path: Path):
 
 
 def _apply_three_way_patch(diff: str, expanded_dir_path: Path):
+    offset = _get_offset(expanded_dir_path)
+
+    git_apply = ["git", "apply", "-3"]
+    if offset:
+        git_apply.extend(["--directory", offset])
+
     try:
-        offset = _get_offset(expanded_dir_path)
-
-        git_apply = ["git", "apply", "-3"]
-        if offset:
-            git_apply.extend(["--directory", offset])
-
         run(
             git_apply,
             input=diff.encode(),
@@ -176,14 +176,20 @@ def _apply_three_way_patch(diff: str, expanded_dir_path: Path):
 
 
 def _get_offset(expanded_dir_path: Path):
-    offset = run(
-        ["git", "rev-parse", "--show-prefix"],
-        stderr=PIPE,
-        stdout=PIPE,
-        check=True,
-        cwd=expanded_dir_path,
-    ).stdout.decode().strip()
-    return offset
+    try:
+        offset = run(
+            ["git", "rev-parse", "--show-prefix"],
+            stderr=PIPE,
+            stdout=PIPE,
+            check=True,
+            cwd=expanded_dir_path,
+        ).stdout.decode().strip()
+        return offset
+    except CalledProcessError as error:
+        if 'not a git repository' in error.stderr.decode():
+            return ''
+        else:
+            raise error
 
 
 def _apply_patch(diff: str, expanded_dir_path: Path):


### PR DESCRIPTION
Previously, `_get_offset` would raise a `CalledProcessError` when given
an `expanded_dir_path` that was not part of a git repo, because `git`
exits nonzero in this case. This error was caught by the the `except
CalledProcessError` clauses in both `_apply_three_way_patch` and
`_apply_patch_with_rejections`, because their `try` blocks included the
`_get_offset` call. However, the `except` clauses were not updated after
additional steps were added to their `try` blocks, so they erroneously
assumed that the caught errors were raised by running the `git apply`
command. The net result of this is that updates would not be applied
when run outside of git repos.

Resolve this bug in two different ways.

First, because the purpose of `_get_offset` is to find the subdirectory
within a git repository, it's sensible to have it return the empty
string as offset when run outside of a git repository. Add
a `try/except` to the function's body to catch the error when `git
rev-parse` exits nonzero, and if the stderr indicates that the given
`expanded_dir_path` is not a git repo, return the empty string;
otherwise, re-raise the error.

Secondly, to prevent confusion about which command errored in
`_apply_three_way_patch` and `apply_patch_with_rejections`, move
everything besides the `run()` call that runs `git apply ...` outside of
the `try` block, including the `_get_offset` call. This ensures that any
unexpected errors raised by `_get_offset` are not erroneously assumed to
be the result of running `git apply`, so the apply functions will not
mistakenly continue in the belief that they have attempted to apply the
diff.

Finally, correct a typo where the three-way flag `-3` was mistakenly
passed to `git apply` in `_apply_patch_with_rejections`, instead of
`--reject`.